### PR TITLE
Fix/remove image button size on post creation

### DIFF
--- a/src/core/components/Uploaders/Image/styles.tsx
+++ b/src/core/components/Uploaders/Image/styles.tsx
@@ -79,8 +79,10 @@ export const RemoveButton = styled(Button).attrs<{
   children: <RemoveIcon />,
 })`
   position: absolute;
-  top: 0.5em;
-  right: 0.5em;
+  height: 2.5vw;
+  aspect-ratio: 1;
+  top: 1vw;
+  right: 1vw;
 `;
 
 export const CircleIcon = styled(ExclamationCircle).attrs<{ icon?: ReactNode }>({ width: 24, height: 24 })`


### PR DESCRIPTION
## Description
This PR introduces a minor UI fix to the size of the removeImage button from post creation

## Demo
<img alt="demo image" src="https://github.com/ILA-26/Amity-Social-Cloud-UIKit-Web-OpenSource/assets/102021206/a231fca7-3601-4ea2-aea0-242b6bb05eb3" width="400px" />

