### PR TITLE
fix: ChatApplication remove button size

### DIFF
--- a/src/core/components/UserChip/styles.tsx
+++ b/src/core/components/UserChip/styles.tsx
@@ -24,6 +24,8 @@ export const Close = styled(Remove).attrs({ width: 12, height: 12 })`
 `;
 
 export const RoundButton = styled(Button)`
-  padding: 0.4rem 0.55rem;
+  padding: 5px;
   border-radius: 10rem;
+  aspect-ratio: 1;
+  width: 25px;
 `;


### PR DESCRIPTION
## Description
This PR fixes an issue with selected users chip remove button on the modal for creating a new chat channel

## Demo
<div style="display: flex; align-items: center; justify-content: center;">
  <img src="https://github.com/AmityCo/Amity-Social-Cloud-UIKit-Web-OpenSource/assets/102021206/a468ae55-28e9-440b-ba1e-429687fe6d48" alt="Image 1" width="45%"/>
   <span>➡️</span>
  <img src="https://github.com/ILA-26/Amity-Social-Cloud-UIKit-Web-OpenSource/assets/102021206/ace2d631-093c-4bae-844b-01beac9adbd5" alt="Image 2" width="45%"/>
</div>
