### PR TITLE
Feat/implement chat title workaround

### DIFF
--- a/src/ila26/chat/components/Chat/index.tsx
+++ b/src/ila26/chat/components/Chat/index.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect } from 'react';
-import {
-  MessageRepository,
-  ChannelRepository,
-  SubChannelRepository,
-  CommunityRepository,
-} from '@amityco/ts-sdk';
+import { MessageRepository, ChannelRepository, SubChannelRepository } from '@amityco/ts-sdk';
 
 import MessageList from '~/ila26/chat/components/MessageList';
 import MessageComposeBar from '~/ila26/chat/components/MessageComposeBar';
@@ -14,16 +9,16 @@ import ChatHeader from '~/ila26/chat/components/ChatHeader';
 import { ChannelContainer } from './styles';
 import { useCustomComponent } from '~/core/providers/CustomComponentsProvider';
 import useChannel from '~/ila26/chat/hooks/useChannel';
-import useChannelMembers from '~/ila26/chat/hooks/useChannelMembers';
 
 export interface ChatProps {
   channelId: string;
-  ila26_variant: 'regular' | 'popup';
+  ila26_displayName?: string;
+  ila26_variant?: 'regular' | 'popup';
   onChatActionClick: () => void;
 }
 
-const Chat = ({ channelId, ila26_variant = 'regular', onChatActionClick }: ChatProps) => {
-  const channel = useChannel(channelId);
+const Chat = (props: ChatProps) => {
+  const channel = useChannel(props.channelId);
   useEffect(() => {
     async function run() {
       if (channel == null) return;
@@ -43,7 +38,7 @@ const Chat = ({ channelId, ila26_variant = 'regular', onChatActionClick }: ChatP
 
   const sendMessage = async (text: string) => {
     return MessageRepository.createMessage({
-      subChannelId: channelId,
+      subChannelId: props.channelId,
       data: { text },
       dataType: 'text',
     });
@@ -51,8 +46,8 @@ const Chat = ({ channelId, ila26_variant = 'regular', onChatActionClick }: ChatP
 
   return (
     <ChannelContainer>
-      <ChatHeader channelId={channelId} onChatActionClick={onChatActionClick} ila26_variant={ila26_variant} />
-      <MessageList channelId={channelId} />
+      <ChatHeader {...props} />
+      <MessageList channelId={props.channelId} />
       <MessageComposeBar onSubmit={sendMessage} />
     </ChannelContainer>
   );

--- a/src/ila26/chat/components/ChatHeader/index.tsx
+++ b/src/ila26/chat/components/ChatHeader/index.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { ChannelRepository } from '@amityco/ts-sdk';
 
 import UserAvatar from '~/ila26/chat/components/UserAvatar';
 import { backgroundImage as userBackgroundImage } from '~/icons/User';
@@ -18,14 +17,14 @@ import {
 } from './styles';
 import { useCustomComponent } from '~/core/providers/CustomComponentsProvider';
 import useChannel from '~/ila26/chat/hooks/useChannel';
+import { ChatProps } from '../Chat';
 
-type ChatHeaderProps = {
-  channelId: string;
-  onChatActionClick: () => void;
-  ila26_variant?: 'regular' | 'popup';
-};
-
-const ChatHeader = ({ channelId, onChatActionClick, ila26_variant = 'regular' }: ChatHeaderProps) => {
+const ChatHeader = ({
+  channelId,
+  ila26_displayName,
+  ila26_variant = 'regular',
+  onChatActionClick,
+}: ChatProps) => {
   const channel = useChannel(channelId);
   const { chatName, chatAvatar } = useChatInfo({ channel });
 
@@ -42,7 +41,9 @@ const ChatHeader = ({ channelId, onChatActionClick, ila26_variant = 'regular' }:
         />
         <ChannelInfo data-qa-anchor="chat-header-channel-info">
           <ChannelName data-qa-anchor="chat-header-channel-info-channel-name">
-            {chatName}
+            {ila26_displayName
+              ? chatName?.replace(ila26_displayName, '').replace(',', '')
+              : chatName}
           </ChannelName>
           <MemberCount data-qa-anchor="chat-header-channel-info-member-count">
             <FormattedMessage id="chat.members.count" values={{ count: channel?.memberCount }} />
@@ -58,8 +59,8 @@ const ChatHeader = ({ channelId, onChatActionClick, ila26_variant = 'regular' }:
   );
 };
 
-export default (props: ChatHeaderProps) => {
-  const CustomComponentFn = useCustomComponent<ChatHeaderProps>('ChatHeader');
+export default (props: ChatProps) => {
+  const CustomComponentFn = useCustomComponent<ChatProps>('ChatHeader');
 
   if (CustomComponentFn) return CustomComponentFn(props);
 

--- a/src/ila26/chat/components/ChatItem/index.tsx
+++ b/src/ila26/chat/components/ChatItem/index.tsx
@@ -29,9 +29,10 @@ interface ChatItemProps {
   channelId: string;
   isSelected: boolean;
   onSelect: ({ channelId, type }: { channelId: string; type: string }) => void;
+  ila26_displayName?: string;
 }
 
-const ChatItem = ({ channelId, isSelected, onSelect }: ChatItemProps) => {
+const ChatItem = ({ channelId, isSelected, onSelect, ila26_displayName }: ChatItemProps) => {
   const channel = useChannel(channelId);
   const { chatName, chatAvatar } = useChatInfo({ channel });
 
@@ -58,7 +59,9 @@ const ChatItem = ({ channelId, isSelected, onSelect }: ChatItemProps) => {
             (channel?.memberCount || 0) > 2 ? communityBackgroundImage : userBackgroundImage
           }
         />
-        <Title>{chatName}</Title>
+        <Title>
+          {ila26_displayName ? chatName?.replace(ila26_displayName, '').replace(',', '') : chatName}
+        </Title>
       </ChatItemLeft>
       {normalizedUnreadCount && (
         <UnreadCount data-qa-anchor="chat-item-unread-count">{normalizedUnreadCount}</UnreadCount>

--- a/src/ila26/chat/components/ChatPopup/styles.ts
+++ b/src/ila26/chat/components/ChatPopup/styles.ts
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 export const Popup = styled.div`
-  position: absolute;
+  position: fixed;
   bottom: 50px;
   right: 50px;
   height: 60vh;

--- a/src/ila26/chat/components/Message/styles.tsx
+++ b/src/ila26/chat/components/Message/styles.tsx
@@ -20,19 +20,22 @@ export const EditingInput = styled.input`
 
 export const SaveIcon = styled(Save)<{ icon?: ReactNode }>`
   opacity: 0.7;
-  padding: 0 10px;
+  width: 20px;
+  margin: 0px 5px;
+  aspect-ratio: 1;
   cursor: pointer;
 `;
 
 export const DeleteIcon = styled(TrashIcon)`
   opacity: 0.7;
-  padding: 0 10px;
   cursor: pointer;
 `;
 
 export const CloseIcon = styled(Close)<{ icon?: ReactNode }>`
   opacity: 0.7;
-  padding: 0 10px;
+  width: 20px;
+  margin: 0px 5px;
+  aspect-ratio: 1;
   cursor: pointer;
 `;
 

--- a/src/ila26/chat/components/RecentChat/index.tsx
+++ b/src/ila26/chat/components/RecentChat/index.tsx
@@ -19,6 +19,7 @@ interface RecentChatProps {
   onAddNewChannelClick: () => void;
   selectedChannelId?: string;
   membershipFilter?: 'all' | 'member' | 'notMember';
+  ila26_displayName?: string;
 }
 
 const RecentChat = ({
@@ -26,6 +27,7 @@ const RecentChat = ({
   onAddNewChannelClick,
   selectedChannelId,
   membershipFilter,
+  ila26_displayName,
 }: RecentChatProps) => {
   const { channels, hasMore, loadMore } = useChannelsCollection({
     membership: membershipFilter,
@@ -64,6 +66,7 @@ const RecentChat = ({
                 <ChatItem
                   key={channel.channelId}
                   channelId={channel.channelId}
+                  ila26_displayName={ila26_displayName}
                   isSelected={selectedChannelId === channel.channelId}
                   onSelect={(data) => {
                     onChannelSelect?.(data);

--- a/src/ila26/chat/pages/Application/index.tsx
+++ b/src/ila26/chat/pages/Application/index.tsx
@@ -16,6 +16,7 @@ type PartialChannel = Pick<Amity.Channel, 'channelId' | 'type'>;
 const ChatApplication = ({
   membershipFilter = 'all',
   defaultChannelId,
+  ila26_displayName,
   onMemberSelect,
   onChannelSelect,
   onAddNewChannel,
@@ -23,6 +24,7 @@ const ChatApplication = ({
 }: {
   membershipFilter?: 'all' | 'member' | 'notMember';
   defaultChannelId: string | null;
+  ila26_displayName?: string;
   onMemberSelect?: (member: Amity.Membership<'channel'>) => void;
   onChannelSelect?: (channel: PartialChannel) => void;
   onAddNewChannel?: () => void;
@@ -92,6 +94,7 @@ const ChatApplication = ({
       <RecentChat
         selectedChannelId={currentChannelData?.channelId}
         membershipFilter={membershipFilter}
+        ila26_displayName={ila26_displayName}
         onChannelSelect={handleChannelSelect}
         onAddNewChannelClick={() => {
           openChatModal();
@@ -102,6 +105,7 @@ const ChatApplication = ({
         <Chat
           channelId={currentChannelData.channelId}
           onChatActionClick={showChatDetails}
+          ila26_displayName={ila26_displayName}
           ila26_variant="regular"
         />
       ) : null}


### PR DESCRIPTION
## Description
This PR implements a workaround to fix chat names, by removing the authenticated user displayName from the title and leaving only the recipient name

#### Additionally
- FIxes icon sizes on edit message