### PR TITLE
feat(Feed): ILA26PP-691 | Fil d'actualités - Preview des vidéos YouTube sur les post amity

### DIFF
--- a/src/ila26/social/components/post/TextContent/YouTubePreview.tsx
+++ b/src/ila26/social/components/post/TextContent/YouTubePreview.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+  DetailsContainer,
+  PreviewContainer,
+  PreviewImage,
+  SubTitle,
+  Title,
+  UnstyledLink,
+} from './styles';
+
+const YouTubePreview = ({ thumbnail, provider, title, author, url }: Props) => {
+  return (
+    <UnstyledLink href={url} rel="noopener noreferrer" target="_blank">
+      <PreviewContainer>
+        <PreviewImage src={thumbnail} alt={`thumbail of a video titled as: ${title}`} />
+        <DetailsContainer>
+          <SubTitle>{provider}</SubTitle>
+          <Title>{title}</Title>
+          <SubTitle>{author}</SubTitle>
+        </DetailsContainer>
+      </PreviewContainer>
+    </UnstyledLink>
+  );
+};
+
+export type Props = {
+  provider: string;
+  title: string;
+  author: string;
+  thumbnail: string;
+  url: string;
+};
+
+export type YouTubeOEmbedResponse = {
+  title: string;
+  url: string;
+  author_name: string;
+  author_url: string;
+  type: string;
+  height: number;
+  width: number;
+  version: string;
+  provider_name: string;
+  provider_url: string;
+  thumbnail_height: number;
+  thumbnail_width: number;
+  thumbnail_url: string;
+  html: string;
+};
+
+export default YouTubePreview;

--- a/src/ila26/social/components/post/TextContent/index.tsx
+++ b/src/ila26/social/components/post/TextContent/index.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import Truncate from 'react-truncate-markup';
+import styled from 'styled-components';
+
+import { processChunks } from '~/core/components/ChunkHighlighter';
+import Button from '~/core/components/Button';
+import Linkify from '~/core/components/Linkify';
+import MentionHighlightTag from '~/core/components/MentionHighlightTag';
+import { Mentioned, findChunks } from '~/helpers/utils';
+import { useCustomComponent } from '~/core/providers/CustomComponentsProvider';
+
+export const PostContent = styled.div`
+  overflow-wrap: break-word;
+  color: ${({ theme }) => theme.palette.neutral.main};
+  white-space: pre-wrap;
+  ${({ theme }) => theme.typography.body}
+`;
+
+export const ReadMoreButton = styled(Button).attrs({ variant: 'secondary' })`
+  color: ${({ theme }) => theme.palette.primary.main};
+  padding: 4px;
+  display: inline-block;
+`;
+
+interface TextContentProps {
+  text?: string;
+  postMaxLines?: number;
+  mentionees?: Mentioned[];
+}
+
+const TextContent = ({ text, postMaxLines, mentionees }: TextContentProps) => {
+  const chunks = useMemo(
+    () => processChunks(text || '', findChunks(mentionees)),
+    [mentionees, text],
+  );
+
+  const textContent = text ? (
+    <PostContent data-qa-anchor="post-text-content">
+      <Truncate.Atom>
+        {chunks.map((chunk) => {
+          const key = `${text}-${chunk.start}-${chunk.end}`;
+          const sub = text.substring(chunk.start, chunk.end);
+          if (chunk.highlight) {
+            const mentionee = mentionees?.find((m) => m.index === chunk.start);
+            if (mentionee) {
+              return (
+                <MentionHighlightTag key={key} mentionee={mentionee}>
+                  {sub}
+                </MentionHighlightTag>
+              );
+            }
+            return <span key={key}>{sub}</span>;
+          }
+          return <Linkify key={key}>{sub}</Linkify>;
+        })}
+      </Truncate.Atom>
+    </PostContent>
+  ) : null;
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const onExpand = () => setIsExpanded(true);
+
+  if (!textContent) return null;
+
+  if (isExpanded) return textContent;
+
+  return (
+    <Truncate
+      lines={postMaxLines}
+      ellipsis={
+        <ReadMoreButton onClick={onExpand}>
+          <FormattedMessage id="post.readMore" />
+        </ReadMoreButton>
+      }
+    >
+      {textContent}
+    </Truncate>
+  );
+};
+
+export default (props: TextContentProps) => {
+  const CustomComponentFn = useCustomComponent<TextContentProps>('UITextContent');
+
+  if (CustomComponentFn) return CustomComponentFn(props);
+
+  return <TextContent {...props} />;
+};

--- a/src/ila26/social/components/post/TextContent/index.tsx
+++ b/src/ila26/social/components/post/TextContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 import Truncate from 'react-truncate-markup';
 import styled from 'styled-components';
@@ -9,6 +9,10 @@ import Linkify from '~/core/components/Linkify';
 import MentionHighlightTag from '~/core/components/MentionHighlightTag';
 import { Mentioned, findChunks } from '~/helpers/utils';
 import { useCustomComponent } from '~/core/providers/CustomComponentsProvider';
+import { getYouTubeOEmbedFromText } from '~/ila26/utils';
+import YouTubePreview, {
+  YouTubeOEmbedResponse,
+} from '~/ila26/social/components/post/TextContent/YouTubePreview';
 
 export const PostContent = styled.div`
   overflow-wrap: break-word;
@@ -27,13 +31,23 @@ interface TextContentProps {
   text?: string;
   postMaxLines?: number;
   mentionees?: Mentioned[];
+  hasChildrenPosts: boolean;
 }
 
-const TextContent = ({ text, postMaxLines, mentionees }: TextContentProps) => {
+const TextContent = ({ text, postMaxLines, mentionees, hasChildrenPosts }: TextContentProps) => {
+  const [oembed, setOembed] = useState<YouTubeOEmbedResponse | null>();
   const chunks = useMemo(
     () => processChunks(text || '', findChunks(mentionees)),
     [mentionees, text],
   );
+
+  useEffect(() => {
+    if (text) {
+      getYouTubeOEmbedFromText(text).then((res) =>
+        setOembed(res),
+      );
+    }
+  }, []);
 
   const textContent = text ? (
     <PostContent data-qa-anchor="post-text-content">
@@ -66,16 +80,27 @@ const TextContent = ({ text, postMaxLines, mentionees }: TextContentProps) => {
   if (isExpanded) return textContent;
 
   return (
-    <Truncate
-      lines={postMaxLines}
-      ellipsis={
-        <ReadMoreButton onClick={onExpand}>
-          <FormattedMessage id="post.readMore" />
-        </ReadMoreButton>
-      }
-    >
-      {textContent}
-    </Truncate>
+    <>
+      <Truncate
+        lines={postMaxLines}
+        ellipsis={
+          <ReadMoreButton onClick={onExpand}>
+            <FormattedMessage id="post.readMore" />
+          </ReadMoreButton>
+        }
+      >
+        {textContent}
+      </Truncate>
+      {oembed && !hasChildrenPosts && (
+        <YouTubePreview
+          thumbnail={oembed.thumbnail_url}
+          provider={oembed.provider_name}
+          title={oembed.title}
+          author={oembed.author_name}
+          url={oembed.url}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/ila26/social/components/post/TextContent/styles.tsx
+++ b/src/ila26/social/components/post/TextContent/styles.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import Button from '~/core/components/Button';
+
+export const PostContent = styled.div`
+  overflow-wrap: break-word;
+  color: ${({ theme }) => theme.palette.neutral.main};
+  white-space: pre-wrap;
+  ${({ theme }) => theme.typography.body}
+`;
+
+export const ReadMoreButton = styled(Button).attrs({ variant: 'secondary' })<{ variant?: string }>`
+  color: ${({ theme }) => theme.palette.primary.main};
+  padding: 4px;
+  display: inline-block;
+`;

--- a/src/ila26/social/components/post/TextContent/styles.tsx
+++ b/src/ila26/social/components/post/TextContent/styles.tsx
@@ -13,3 +13,34 @@ export const ReadMoreButton = styled(Button).attrs({ variant: 'secondary' })<{ v
   padding: 4px;
   display: inline-block;
 `;
+
+export const UnstyledLink = styled.a`
+  text-decoration: none;
+  color: inherit;
+`;
+
+export const PreviewContainer = styled.div`
+  background-color: #eef0f3;
+  margin-top: 15px;
+  border: 1px solid lightgray;
+`;
+
+export const PreviewImage = styled.img`
+  aspect-ratio: 2;
+  object-fit: cover;
+  width: 100%;
+`;
+
+export const DetailsContainer = styled.div`
+  padding: 5px 15px 15px 15px;
+  margin: 0;
+`;
+
+export const Title = styled.h2`
+  font-size: 16px;
+  margin: 0px;
+`;
+
+export const SubTitle = styled.span`
+  color: #4d545d;
+`;

--- a/src/ila26/social/components/post/TextContent/ui.stories.jsx
+++ b/src/ila26/social/components/post/TextContent/ui.stories.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PostTextContent from '.';
+import { useArgs } from '@storybook/client-api';
+
+export default {
+  title: 'Ui Only/Social/Post/TextContent',
+};
+
+export const UIPostTextContent = {
+  render: () => {
+    const [props] = useArgs();
+    return (
+      <div
+        style={{
+          width: '200px',
+          height: '100px',
+          border: '1px dashed darkgrey',
+          padding: '20px',
+          borderRadius: '6px',
+        }}
+      >
+        <PostTextContent {...props} />
+      </div>
+    );
+  },
+
+  name: 'Text content',
+
+  args: {
+    text: 'Some post text that goes over maxPostLines lines long',
+    postMaxLines: 2,
+  },
+
+  argTypes: {
+    text: { control: { type: 'text' } },
+    postMaxLines: { control: { type: 'number' } },
+  },
+};

--- a/src/ila26/utils.ts
+++ b/src/ila26/utils.ts
@@ -1,3 +1,4 @@
+import { YouTubeOEmbedResponse } from './social/components/post/TextContent/YouTubePreview';
 import { ILA26_internalElementsTypes } from './types/customPosts';
 
 const serviceOffersRegex = /.+offers\/([^/]+)/;
@@ -92,3 +93,37 @@ export const isToday = (date: Date): boolean => {
 };
 
 export type ILA26_Values<T> = T[keyof T];
+
+export const getYouTubeOEmbedFromText = async (
+  text: string,
+): Promise<YouTubeOEmbedResponse | null> => {
+  // Regular expression to find the first YouTube link
+  const youtubeRegex =
+    /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]{11})/;
+  const match = text.match(youtubeRegex);
+
+  // If no YouTube link is found, return null
+  if (!match) {
+    return null;
+  }
+
+  // Construct the oEmbed URL using the matched YouTube link
+  const youtubeUrl = match[0];
+  const oEmbedEndpoint = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+    youtubeUrl,
+  )}&format=json`;
+
+  try {
+    const response = await fetch(oEmbedEndpoint);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch oEmbed data: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return { ...data, url: youtubeUrl };
+  } catch (error) {
+    console.error('Error fetching oEmbed data:', error);
+    return null;
+  }
+};

--- a/src/social/components/post/Post/Content/index.tsx
+++ b/src/social/components/post/Post/Content/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import TextContent from '~/social/components/post/TextContent';
+import TextContent from '~/ila26/social/components/post/TextContent';
 import ImageContent from '~/social/components/post/ImageContent';
 import VideoContent from '~/social/components/post/VideoContent';
 import FileContent from '~/social/components/post/FileContent';
@@ -11,13 +11,14 @@ import ILA26_CustomPostContent from '~/ila26/components/ILA26_CustomPostContent'
 
 interface PostContentProps {
   data?: any;
-  dataType?: Amity.PostContentType & ILA26_internalElementsTypes;
+  dataType?: Amity.PostContentType;
   postMaxLines?: number;
   mentionees?: Amity.User[];
   metadata?: ILA26_internalData;
+  hasChildrenPosts: boolean;
 }
 
-const PostContent = ({ data, dataType, postMaxLines, mentionees, metadata }: PostContentProps) => {
+const PostContent = ({ data, dataType, postMaxLines, mentionees, metadata, hasChildrenPosts }: PostContentProps) => {
   if (!data) return null;
 
   if (Object.values(ILA26_customTypeDataTypes).includes(dataType ?? '')) {
@@ -29,7 +30,7 @@ const PostContent = ({ data, dataType, postMaxLines, mentionees, metadata }: Pos
   }
 
   if (dataType === 'text') {
-    return <TextContent {...data} postMaxLines={postMaxLines} mentionees={mentionees} />;
+    return <TextContent {...data} postMaxLines={postMaxLines} mentionees={mentionees} hasChildrenPosts={hasChildrenPosts} />;
   }
   if (dataType === 'image') {
     return <ImageContent {...data} postMaxLines={postMaxLines} mentionees={mentionees} />;

--- a/src/social/components/post/Post/DefaultPostRenderer.tsx
+++ b/src/social/components/post/Post/DefaultPostRenderer.tsx
@@ -185,6 +185,7 @@ const DefaultPostRenderer = ({
             postMaxLines={postMaxLines}
             mentionees={post?.metadata?.mentioned}
             metadata={post?.metadata}
+            hasChildrenPosts={hasChildrenPosts}
           />
 
           {hasChildrenPosts && <ChildrenContent contents={childrenPosts} />}


### PR DESCRIPTION
## 📄 Description
This PR introduces the feature of having Facebook like previewing cards for YouTube videos shared on posts as links
> References [ILA26PP-691](https://ila26.atlassian.net/browse/ILA26PP-691)

## 🖥️ Demo
![youtube_preview](https://github.com/user-attachments/assets/7294389a-a4fe-40ba-8dc7-35c4480bd5a4)


[ILA26PP-691]: https://ila26.atlassian.net/browse/ILA26PP-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ