### PR TITLE
Feat(Feed): ILA26PP-706 | Accueil - Pouvoir publier d'une communauté sans que la personne aparaîsse

### DIFF
--- a/src/social/components/post/Header/UIPostHeader.tsx
+++ b/src/social/components/post/Header/UIPostHeader.tsx
@@ -26,6 +26,7 @@ type UIPostHeaderProps = ReturnType<typeof usePostHeaderProps>;
 
 const UIPostHeader = ({
   avatarFileUrl,
+  communityAvatarFileUrl,
   postAuthorName,
   postTargetName,
   timeAgo,
@@ -42,6 +43,7 @@ const UIPostHeader = ({
   if (CustomComponentFn)
     return CustomComponentFn({
       avatarFileUrl,
+      communityAvatarFileUrl,
       postAuthorName,
       postTargetName,
       timeAgo,
@@ -57,21 +59,24 @@ const UIPostHeader = ({
   const renderPostNames = () => {
     return (
       <PostNamesContainer data-qa-anchor="post-header-post-names">
-        <Truncate lines={3}>
-          <Name
-            data-qa-anchor="post-header-post-name"
-            className={cx({ clickable: !!onClickUser })}
-            onClick={onClickUser}
-          >
-            {postAuthorName}
-          </Name>
-        </Truncate>
+        {!postTargetName ||
+          (postTargetName && !isModerator && (
+            <Truncate lines={3}>
+              <Name
+                data-qa-anchor="post-header-post-name"
+                className={cx({ clickable: !!onClickUser })}
+                onClick={onClickUser}
+              >
+                {postAuthorName}
+              </Name>
+            </Truncate>
+          ))}
 
         {isBanned && <BanIcon />}
 
-        {postTargetName && !hidePostTarget && (
+        {postTargetName && (!hidePostTarget || isModerator) && (
           <>
-            <ArrowSeparator />
+            {!isModerator && <ArrowSeparator />}
             <Name
               data-qa-anchor="post-header-post-target-name"
               className={cx({ clickable: !!onClickCommunity })}
@@ -88,11 +93,11 @@ const UIPostHeader = ({
   const renderAdditionalInfo = () => {
     return (
       <AdditionalInfo data-qa-anchor="post-header-additional-info" showTime={!!timeAgo}>
-        {isModerator && (
+        {/* {isModerator && (
           <ModeratorBadge data-qa-anchor="post-header-additional-info-moderator-badge">
             <ShieldIcon /> <FormattedMessage id="moderator" />
           </ModeratorBadge>
-        )}
+        )} */}
 
         {timeAgo && (
           <Time data-qa-anchor="post-header-additional-info-time-ago" date={timeAgo.getTime()} />
@@ -111,7 +116,7 @@ const UIPostHeader = ({
     <PostHeaderContainer data-qa-anchor="post-header">
       <Avatar
         data-qa-anchor="post-header-avatar"
-        avatar={avatarFileUrl}
+        avatar={(postTargetName && isModerator) ? communityAvatarFileUrl : avatarFileUrl }
         backgroundImage={UserImage}
         loading={loading}
         onClick={onClickUser}

--- a/src/social/components/post/Header/hooks.ts
+++ b/src/social/components/post/Header/hooks.ts
@@ -1,4 +1,5 @@
 import { useIntl } from 'react-intl';
+import useImage from '~/core/hooks/useImage';
 import useUser from '~/core/hooks/useUser';
 import { isAdmin, isModerator } from '~/helpers/permissions';
 import useCommunity from '~/social/hooks/useCommunity';
@@ -22,6 +23,7 @@ export const usePostHeaderProps = ({
   const user = useUser(post?.postedUserId);
 
   const community = useCommunity(post?.targetId);
+  const communityAvatarFileUrl = useImage({ fileId: community?.avatarFileId, imageSize: 'small' });
   const { isModerator: isCommunityModerator } = useCommunityPostPermission({
     community,
     post,
@@ -38,6 +40,7 @@ export const usePostHeaderProps = ({
 
   return {
     avatarFileUrl: avatarFileUrl,
+    communityAvatarFileUrl: communityAvatarFileUrl,
     postAuthorName: user?.displayName || formatMessage({ id: 'anonymous' }),
     postTargetName: postTargetName,
     timeAgo: new Date(post?.createdAt),


### PR DESCRIPTION
## Description
This PR introduces the feature of hiding the poster name and avatar and replacing it with the name and avatar of the community posted (only when the user is a moderator).

> References [ILA26PP-706](https://ila26.atlassian.net/browse/ILA26PP-706)

[ILA26PP-706]: https://ila26.atlassian.net/browse/ILA26PP-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ