### PR TITLE
Fix(Feed) | Poster as moderator name showing on global and community feed

### DIFF
--- a/src/ila26/fr.json
+++ b/src/ila26/fr.json
@@ -14,7 +14,7 @@
   "followedEnterprises": "Sociétés suivies",
   "loadMore": "Charger plus",
   "categoryList": "Catégories",
-  "recommendedList": "Communautés recommandés pour vous",
+  "recommendedList": "Communautés recommandées pour vous",
   "exploreHeader.searchCommunityTitle": "Explorer les communautés",
   "exploreHeader.searchCommunityPlaceholder": "Rechercher des communautés...",
   "exploreHeader.createCommunityTitle": "ou créez la vôtre !",

--- a/src/social/components/post/Header/UIPostHeader.tsx
+++ b/src/social/components/post/Header/UIPostHeader.tsx
@@ -55,11 +55,11 @@ const UIPostHeader = ({
       loading,
       isBanned,
     });
+  const showName =
+    !postTargetName || (postTargetName && !isModerator) || (postTargetName && hidePostTarget);
+  const showCommunity = postTargetName && !hidePostTarget;
 
   const renderPostNames = () => {
-    const showName = !postTargetName || !isModerator;
-    const showCommunity = postTargetName && !hidePostTarget;
-
     return (
       <PostNamesContainer data-qa-anchor="post-header-post-names">
         {showName && (
@@ -78,7 +78,7 @@ const UIPostHeader = ({
 
         {showCommunity && (
           <>
-            {!isModerator && <ArrowSeparator />}
+            {showName && <ArrowSeparator />}
             <Name
               data-qa-anchor="post-header-post-target-name"
               className={cx({ clickable: !!onClickCommunity })}
@@ -95,11 +95,11 @@ const UIPostHeader = ({
   const renderAdditionalInfo = () => {
     return (
       <AdditionalInfo data-qa-anchor="post-header-additional-info" showTime={!!timeAgo}>
-        {/* {isModerator && (
+        {isModerator && hidePostTarget && (
           <ModeratorBadge data-qa-anchor="post-header-additional-info-moderator-badge">
             <ShieldIcon /> <FormattedMessage id="moderator" />
           </ModeratorBadge>
-        )} */}
+        )}
 
         {timeAgo && (
           <Time data-qa-anchor="post-header-additional-info-time-ago" date={timeAgo.getTime()} />
@@ -118,7 +118,7 @@ const UIPostHeader = ({
     <PostHeaderContainer data-qa-anchor="post-header">
       <Avatar
         data-qa-anchor="post-header-avatar"
-        avatar={postTargetName && isModerator ? communityAvatarFileUrl : avatarFileUrl}
+        avatar={showName ? avatarFileUrl : communityAvatarFileUrl}
         backgroundImage={UserImage}
         loading={loading}
         onClick={onClickUser}

--- a/src/social/components/post/Header/UIPostHeader.tsx
+++ b/src/social/components/post/Header/UIPostHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import cx from 'clsx';
 import Truncate from 'react-truncate-markup';
@@ -55,11 +55,17 @@ const UIPostHeader = ({
       loading,
       isBanned,
     });
-  const showName =
-    !postTargetName || (postTargetName && !isModerator) || (postTargetName && hidePostTarget);
-  const showCommunity = postTargetName && !hidePostTarget;
 
-  const renderPostNames = () => {
+  const showName = useMemo(
+    () => !postTargetName || (postTargetName && !isModerator) || (postTargetName && hidePostTarget),
+    [postTargetName, isModerator, hidePostTarget],
+  );
+  const showCommunity = useMemo(
+    () => postTargetName && !hidePostTarget,
+    [postTargetName, hidePostTarget],
+  );
+
+  const renderPostNames = useCallback(() => {
     return (
       <PostNamesContainer data-qa-anchor="post-header-post-names">
         {showName && (
@@ -90,9 +96,9 @@ const UIPostHeader = ({
         )}
       </PostNamesContainer>
     );
-  };
+  }, [postTargetName, postAuthorName, isModerator, isBanned, hidePostTarget]);
 
-  const renderAdditionalInfo = () => {
+  const renderAdditionalInfo = useCallback(() => {
     return (
       <AdditionalInfo data-qa-anchor="post-header-additional-info" showTime={!!timeAgo}>
         {isModerator && hidePostTarget && (
@@ -112,7 +118,7 @@ const UIPostHeader = ({
         )}
       </AdditionalInfo>
     );
-  };
+  }, [timeAgo, isEdited]);
 
   return (
     <PostHeaderContainer data-qa-anchor="post-header">

--- a/src/social/hooks/collections/useCommunityModeratorsCollection.ts
+++ b/src/social/hooks/collections/useCommunityModeratorsCollection.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { CommunityRepository } from '@amityco/ts-sdk';
 
 import useLiveCollection from '~/core/hooks/useLiveCollection';
@@ -5,10 +6,14 @@ import { MemberRoles } from '~/social/constants';
 
 const { COMMUNITY_MODERATOR } = MemberRoles;
 
-export default function useCommunityModeratorsCollection(communityId?: string) {
+export default function useCommunityModeratorsCollection(
+  communityId?: string,
+  options?: { limit: number },
+) {
+  const { limit } = options ?? {};
   const { items, ...rest } = useLiveCollection({
     fetcher: CommunityRepository.Membership.getMembers,
-    params: { communityId: communityId as string, roles: [COMMUNITY_MODERATOR] },
+    params: { communityId: communityId as string, roles: [COMMUNITY_MODERATOR], limit },
     shouldCall: () => !!communityId,
   });
 

--- a/src/social/hooks/useCommunityPostPermission.ts
+++ b/src/social/hooks/useCommunityPostPermission.ts
@@ -16,7 +16,7 @@ const useCommunityPostPermission = ({
   community?: Amity.Community | null;
   userId?: string;
 }) => {
-  const { moderators } = useCommunityModeratorsCollection(community?.communityId);
+  const { moderators } = useCommunityModeratorsCollection(community?.communityId, { limit: 100 });
   const { members } = useCommunityMembersCollection(community?.communityId);
   const { posts: reviewingPosts } = usePostsCollection({
     targetType: 'community',

--- a/src/social/pages/Application/index.tsx
+++ b/src/social/pages/Application/index.tsx
@@ -59,7 +59,7 @@ const Community = ({
             onClick={() => onClickCommunity(undefined as unknown as string)}
           >
             <BackIcon />
-            <FormattedMessage id="backTitle" />
+            <FormattedMessage id="exploreHeader.searchCommunityTitle" />
           </Button>
         ) // hide community news feed and fallback to explore
       }


### PR DESCRIPTION
## Description
This PR fixes an issue with the faulty display of poster names on global and community feeds.
After digging, the issue stemmed from an incorrect fetching of the moderators list, resulting in inconsistent results from one community to another