### PR TITLE
Feat(Community) : Reduce community feed width

### DIFF
--- a/src/social/pages/CommunityFeed/index.tsx
+++ b/src/social/pages/CommunityFeed/index.tsx
@@ -13,7 +13,7 @@ import CommunityMembers from '~/social/components/CommunityMembers';
 import FeedHeaderTabs from '~/social/components/FeedHeaderTabs';
 import { CommunityFeedTabs } from './constants';
 import { getTabs } from './utils';
-import { DeclineBanner, Wrapper } from './styles';
+import { Box, DeclineBanner, FeedContainer, Wrapper } from './styles';
 import useCommunityPermission from '~/social/hooks/useCommunityPermission';
 import useCommunitySubscription from '~/social/hooks/useCommunitySubscription';
 import usePostsCollection from '~/social/hooks/collections/usePostsCollection';
@@ -84,15 +84,19 @@ const CommunityFeed = ({
       />
 
       {activeTab === CommunityFeedTabs.TIMELINE && (
-        <Feed
-          targetType={'community'}
-          targetId={communityId}
-          readonly={!isJoined}
-          showPostCreator={isJoined}
-          feedType={'published'}
-          ILA26_communityManagerProps={ILA26_communityManagerProps}
-          ILA26_getInternalData={ILA26_getInternalData}
-        />
+        <FeedContainer>
+          <Box>
+            <Feed
+              targetType={'community'}
+              targetId={communityId}
+              readonly={!isJoined}
+              showPostCreator={isJoined}
+              feedType={'published'}
+              ILA26_communityManagerProps={ILA26_communityManagerProps}
+              ILA26_getInternalData={ILA26_getInternalData}
+            />
+          </Box>
+        </FeedContainer>
       )}
 
       {activeTab === CommunityFeedTabs.GALLERY && (

--- a/src/social/pages/CommunityFeed/styles.tsx
+++ b/src/social/pages/CommunityFeed/styles.tsx
@@ -15,3 +15,13 @@ export const DeclineBanner = styled.div`
   padding: 12px 16px;
   border-radius: 4px;
 `;
+
+export const FeedContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export const Box = styled.div`
+  min-width: 800px;
+  width: 60%;
+`;


### PR DESCRIPTION
## Description
This PR fixes the issue of having images take up the whole screen on community posts with images, the fix is reducing the width of the community.

## Demo
![image](https://github.com/user-attachments/assets/11f42d31-1079-4a07-84f6-76bfa0d83c68)
