### PR TITLE
Fix(Explore Communities) : IBT-425 | Search Bar Appears in Front of Notifications

### DIFF
--- a/src/ila26/social/pages/Explore/index.tsx
+++ b/src/ila26/social/pages/Explore/index.tsx
@@ -18,7 +18,7 @@ const ExplorePage = () => {
   return (
     <PageContainer>
       <HeaderSection>
-        <SocialSearch sticky />
+        <SocialSearch />
         <Button variant="primary" onClick={handleToggleCreationModal}>
           <PlusIcon />{' '}
           <span>


### PR DESCRIPTION
## Description
This PR introduces a fix to UI, specifically the issue of the input used to search for communities being displayed above everything, including the notifications popup menu
> References [IBT-425](https://ila26.atlassian.net/browse/IBT-425)

[IBT-425]: https://ila26.atlassian.net/browse/IBT-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ