### PR TITLE
Feat(Communities) : Order recommended communities by membersCount

### DIFF
--- a/src/ila26/social/components/community/RecommendedCommunities/index.tsx
+++ b/src/ila26/social/components/community/RecommendedCommunities/index.tsx
@@ -49,15 +49,9 @@ const RecommendedList = () => {
     limit: 6,
   });
 
-  const parseOrderFromDescription = useCallback((description: string | undefined): number => {
-    if (!description) return Infinity;
-    const match = description.match(/<!--order:(\d+)-->/);
-    return match ? parseInt(match[1], 10) : Infinity;
-  }, []);
-
   const sortedCommunities: Amity.Community[] = useMemo(() => {
     return communities.sort((a, b) => {
-      return parseOrderFromDescription(a.description) - parseOrderFromDescription(b.description);
+      return b.membersCount - a.membersCount;
     });
   }, [communities]);
 


### PR DESCRIPTION
## Description
This PR changes the way recommended communities are ordered, from custom order by admins using unique tokens to being ordered by the members' count.